### PR TITLE
checkboxes for Leave Types Allowed / Private, government worker sample

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -439,12 +439,12 @@ class MicrosimGUI(Tk):
         yr = self.general_params.year
         fp_fmla_in = self.general_params.fmla_file
         fp_cps_in = './data/cps/CPS%sextract.csv' % (yr - 2)
-        fp_acsh_in = self.general_params.acs_directory + '/household_files'
-        fp_acsp_in = self.general_params.acs_directory + '/person_files'
+        fp_acsh_in = self.general_params.acs_directory + '/%s/household_files' % yr
+        fp_acsp_in = self.general_params.acs_directory + '/%s/person_files' % yr
         state_of_work = self.general_params.state_of_work
         if state_of_work:
-            fp_acsh_in = self.general_params.acs_directory + '/pow_household_files'
-            fp_acsp_in = self.general_params.acs_directory + '/pow_person_files'
+            fp_acsh_in = self.general_params.acs_directory + '/%s/pow_household_files' % yr
+            fp_acsp_in = self.general_params.acs_directory + '/%s/pow_person_files' % yr
         fp_fmla_out = './data/fmla_2012/fmla_clean_2012.csv'
         fp_cps_out = './data/cps/cps_for_acs_sim.csv'
         fp_acs_out = './data/acs/'

--- a/Utils.py
+++ b/Utils.py
@@ -104,12 +104,12 @@ DEFAULT_STATE_PARAMS = {
 # The possible leave type options
 LEAVE_TYPES = ['Own Health', 'Maternity', 'New Child', 'Ill Child', 'Ill Spouse', 'Ill Parent']
 
-STATE_CODES = ['AK', 'AL', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS',
-               'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC',
-               'ND', 'OH', 'OK', 'OR', 'PA', 'PR', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'VI', 'WA', 'WV',
-               'WI', 'WY']
+# STATE_CODES = ['AK', 'AL', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS',
+#                'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC',
+#                'ND', 'OH', 'OK', 'OR', 'PA', 'PR', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'VI', 'WA', 'WV',
+#                'WI', 'WY']
 
-# STATE_CODES = ['VT', 'WY']
+STATE_CODES = ['VT', 'WY']
 
 
 class Parameters:

--- a/_4_clean_ACS.py
+++ b/_4_clean_ACS.py
@@ -60,9 +60,9 @@ class DataCleanerACS:
         cps = pd.read_csv('./data/cps/cps_for_acs_sim.csv')
 
         # Load ACS household data and create some variables
-        fp_d_hh = self.fp_h + '/ss%sh%s.csv' % (self.yr, self.st)
+        fp_d_hh = self.fp_h + '/20%s/ss%sh%s.csv' % (self.yr, self.yr, self.st)
         if self.state_of_work:
-            fp_d_hh = self.fp_h + '/h%s_%s_pow.csv' % (self.dct_st[self.st], self.st)
+            fp_d_hh = self.fp_h + '/20%s/h%s_%s_pow.csv' % (self.yr, self.dct_st[self.st], self.st)
         d_hh = pd.read_csv(fp_d_hh)
         d_hh["nochildren"] = pd.get_dummies(d_hh["FPARC"])[4]
         d_hh['faminc'] = d_hh['FINCP'] * d_hh['ADJINC'] / self.adjinc / 1000  # adjust to 2012 thousand dollars to conform with FMLA 2012 data

--- a/_4_clean_ACS.py
+++ b/_4_clean_ACS.py
@@ -59,9 +59,9 @@ class DataCleanerACS:
         '''
 
         # Load ACS household data and create some variables
-        fp_d_hh = self.fp_h + '/20%s/ss%sh%s.csv' % (self.yr, self.yr, self.st)
+        fp_d_hh = self.fp_h + '/ss%sh%s.csv' % (str(self.yr)[2:], st)
         if self.state_of_work:
-            fp_d_hh = self.fp_h + '/20%s/h%s_%s_pow.csv' % (self.yr, self.dct_st[self.st], self.st)
+            fp_d_hh = self.fp_h + '/h%s_%s_pow.csv' % (self.dct_st[st], st)
         d_hh = pd.read_csv(fp_d_hh)
         d_hh["nochildren"] = pd.get_dummies(d_hh["FPARC"])[4]
         d_hh['faminc'] = d_hh['FINCP'] * d_hh['ADJINC'] / self.adjinc / 1000  # adjust to 2012 thousand dollars to conform with FMLA 2012 data
@@ -82,9 +82,9 @@ class DataCleanerACS:
         print('Cleaning ACS data. State chosen = %s. Chunk size = %s ACS rows' % (st.upper(), chunk_size))
 
         # set file path to person file, per state_of_work value
-        fp_d_p = self.fp_p + "/%s/ss%sp%s.csv" % (self.yr, str(self.yr)[:2], st)
+        fp_d_p = self.fp_p + "/ss%sp%s.csv" % (str(self.yr)[:2], st)
         if self.state_of_work:
-            fp_d_p = self.fp_p + '/%s/p%s_%s_pow.csv' % (self.yr, self.dct_st[st], st)
+            fp_d_p = self.fp_p + '/p%s_%s_pow.csv' % (self.dct_st[st], st)
 
         # process person data by chunk
         for d in pd.read_csv(fp_d_p, chunksize=chunk_size):

--- a/validate_model.py
+++ b/validate_model.py
@@ -319,6 +319,7 @@ format_chart(fig, ax, title, bg_color='white', fg_color='k')
 plt.savefig(fp_out + 'program_costs.png', facecolor='white', edgecolor='grey') #
 
 
+
 ################################################################################################
 
 


### PR DESCRIPTION
1. Uncheck Leave Types Allowed does not work - I unchecked a few and still got positive outlay for 6 types.
2. As you mentioned, we should implement the checkbox for Private employees.
3. We need a more friendly way to ingest government employee ACS sample. We have the reduced ACS for all gov't workers, and I was thinking that we should make a special case in the code so that if use selected state = All , unchecks Private workers, and checks at least one type of gov't worker class, _4_clean_ACS.py would directly read in the gov't worker ACS data files, instead of looping through all 50 states.