### PR TITLE
[for dev] bracket rrp back/frond end port bug fixed. Some more TODOs in comment.

### DIFF
--- a/_5_simulation.py
+++ b/_5_simulation.py
@@ -516,7 +516,7 @@ class SimulationEngine:
             # This ensures dep allowance is generously applied
 
             # init effective_rrp
-            acs['effective_rrp'] = np.nan
+            acs['effective_rrp'] = 0
             # 1. wage bracket-specific rrp (e.g. progressive) design
             if params['rrp_flat']: # flat rrp
                 acs['effective_rrp'] = params['rrp'] # scalar flat rrp
@@ -530,9 +530,8 @@ class SimulationEngine:
                 'dependency_allowance_profile']  # rrp increment by ndep, len of this is max ndep allowed
             cum_profile = np.cumsum(np.array(dependency_allowance_profile))
             if dependency_allowance:
-                acs['effective_rrp'] += [
-                    cum_profile[int(min(x, len(cum_profile))) - 1]  # ndep-1 to get index in cum_profile
-                    if x > 0 else 0 for x in acs['ndep_spouse_kid']]
+                acs['effective_rrp'] = acs['effective_rrp'] + [cum_profile[int(min(x, len(cum_profile))) - 1] if x > 0 else 0 for x in acs['ndep_spouse_kid']] # ndep-1=ix in cum_profile
+                # apply upper bound 1
                 acs['effective_rrp'] = [min(x, 1) for x in acs['effective_rrp']]
 
             # Given cf-len, get cp-len

--- a/_5a_aux_functions.py
+++ b/_5a_aux_functions.py
@@ -146,13 +146,13 @@ def get_average_rrp(wage, cuts, rates):
     # get average rrp
     rrp_avg = replace_amount/wage
 
-    return replace_amount, rrp_avg
+    return rrp_avg
 
 # test
-wage = 200
-cuts = [30, 50, 80, 100]
-rates = [0.8, 0.6, 0.4, 0.2, 0.1]
-get_average_rrp(wage, cuts, rates)
+# wage = 200
+# cuts = [30, 50, 80, 100]
+# rates = [0.8, 0.6, 0.4, 0.2, 0.1]
+# get_average_rrp(wage, cuts, rates)
 
 
 # Adjust unconditional prob vector and conditional prob matrix wrt logical restrictions at worker level


### PR DESCRIPTION
1. Change the option name from **Static** to **Flat**.
2. Change the option name from **Progressive** to **Wage Bracket-Based**, because we generally allow any rates between 0, 1 to be specified for each wage bracket. If the rates decreases as wage bracket increases, it's progressive. This will give users more flexibility in program design.
3. I note that current GUI has a validation check for Wage Replacement between 0, 1 and Upper Bound >= Lower Bound, which is great. My only suggestion is to make the check for Upper Bound **strictly >** Lower Bound, so we don't accept bounds that are the same resulting in meaningless bracket with length 0. This also ensures bracket like (0, 0] will not be accepted, e.g. when users select Wage Bracket-Based (currently Progressive) but forgot to input anything into the bounds/rates fields.